### PR TITLE
Add cross compatibility for python 2 and 3

### DIFF
--- a/pylint_json2html/__init__.py
+++ b/pylint_json2html/__init__.py
@@ -130,7 +130,7 @@ class JSONSetEncoder(json.JSONEncoder):
     def default(self, o):  # pylint: disable=E0202
         if isinstance(o, set):
             return list(o)
-        return super().default(o)
+        return super(JSONSetEncoder, self).default(o)
 
 
 class JsonExtendedReporter(BaseReporter):
@@ -152,7 +152,7 @@ class JsonExtendedReporter(BaseReporter):
     extension = 'json'
 
     def __init__(self, output=None):
-        super().__init__(output=output)
+        super(JsonExtendedReporter, self).__init__(output=output)
         self._messages = []
 
     def handle_message(self, msg):

--- a/pylint_json2html/__init__.py
+++ b/pylint_json2html/__init__.py
@@ -4,6 +4,7 @@ import argparse
 import collections
 import json
 import sys
+from __future__ import print_function
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 from pylint.interfaces import IReporter


### PR DESCRIPTION
This PR resolves errors that emerge when loading the plugin within python2 environments. 

When executing a load-plugins command similar to:
```pylint --exit-zero --load-plugins=pylint_json2html --output-format=jsonextended *.py > ../pylint.json```

The following error would occur:
```python
File "/mnt/c/Users/username/Envs/pytest/local/lib/python2.7/site-packages/pylint_json2html/__init__.py", line 199
    print(json.dumps(reports, cls=JSONSetEncoder, indent=4), file=self.out)
```

Importing the print_function will allow the `file=self.out` to execute.
